### PR TITLE
Re-enable precommit script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lib": "babel src -d lib",
     "lint": "standard-markdown && standard src stories",
     "posttest": "npm run size",
+    "precommit": "lint-staged",
     "prepublish": "npm run build",
     "build": "node scripts/build",
     "pretest": "npm run lint",


### PR DESCRIPTION
Close #29, bug in rxjs has been fixed in 5.5.4 release